### PR TITLE
Model and Query Exceptions

### DIFF
--- a/dvelum/src/Dvelum/App/Model/Group.php
+++ b/dvelum/src/Dvelum/App/Model/Group.php
@@ -39,8 +39,8 @@ class Group extends Model
 		if($this->cache && $data = $this->cache->load('groups_list'))
 			return $data;
 
-		$sql = $this->dbSlave->select()->from($this->table() , ['id' , 'title']);
-		$data = $this->dbSlave->fetchAll($sql);
+		$sql = $this->db->select()->from($this->table() , ['id' , 'title']);
+		$data = $this->db->fetchAll($sql);
 
 		if(!empty($data))
 			$data = Utils::collectData('id', 'title', $data);

--- a/dvelum/src/Dvelum/App/Model/Permissions.php
+++ b/dvelum/src/Dvelum/App/Model/Permissions.php
@@ -49,11 +49,11 @@ class Permissions extends Model
          */
         if ($groupId) {
 
-            $sql = $this->dbSlave->select()
+            $sql = $this->db->select()
                 ->from($this->table(), self::$fields)
                 ->where('`group_id` = ' . intval($groupId))
                 ->where('`user_id` IS NULL');
-            $groupRights = $this->dbSlave->fetchAll($sql);
+            $groupRights = $this->db->fetchAll($sql);
 
             if (!empty($groupRights))
                 $data = Utils::rekey('module', $groupRights);
@@ -61,12 +61,12 @@ class Permissions extends Model
         /*
          * Load permissions for user
          */
-        $sql = $this->dbSlave->select()
+        $sql = $this->db->select()
             ->from($this->table(), self::$fields)
             ->where('`user_id` = ' . intval($userId))
             ->where('`group_id` IS NULL');
 
-        $userRights = $this->dbSlave->fetchAll($sql);
+        $userRights = $this->db->fetchAll($sql);
 
         /*
          * Replace group permissions by permissions redefined for concrete user
@@ -105,9 +105,9 @@ class Permissions extends Model
      */
     public function getRecords($userId, $groupId)
     {
-        $sql = $this->dbSlave->select()->from($this->table())->where('user_id =?', $userId)->orWhere('group_id =?', $groupId);
+        $sql = $this->db->select()->from($this->table())->where('user_id =?', $userId)->orWhere('group_id =?', $groupId);
         try {
-            return $this->dbSlave->fetchAll($sql);
+            return $this->db->fetchAll($sql);
         } catch (Exception $e) {
             $this->logError($e->getMessage());
             return [];
@@ -122,11 +122,11 @@ class Permissions extends Model
     {
         $modules = Config::factory(Config\Factory::File_Array, Config::storage()->get('main.php')->get('backend_modules'));
 
-        $sql = $this->dbSlave->select()
+        $sql = $this->db->select()
             ->from($this->table(), array('module'))
             ->distinct();
 
-        $data = $this->dbSlave->fetchCol($sql);
+        $data = $this->db->fetchCol($sql);
 
         if (!empty($data))
             foreach ($data as $name)
@@ -148,12 +148,12 @@ class Permissions extends Model
         if ($this->cache && $data = $this->cache->load('group_permissions' . $groupId))
             return $data;
 
-        $sql = $this->dbSlave->select()
+        $sql = $this->db->select()
             ->from($this->table(), self::$fields)
             ->where('`group_id` = ' . intval($groupId))
             ->where('`user_id` IS NULL');
 
-        $data = $this->dbSlave->fetchAll($sql);
+        $data = $this->db->fetchAll($sql);
 
         if (!empty($data))
             $data = Utils::rekey('module', $data);
@@ -267,12 +267,12 @@ class Permissions extends Model
         $groupPermissions = [];
 
         if ($userInfo['group_id']) {
-            $sql = $this->dbSlave->select()
+            $sql = $this->db->select()
                 ->from($this->table(), self::$fields)
                 ->where('`group_id` = ' . intval($userInfo['group_id']))
                 ->where('`user_id` IS NULL');
 
-            $groupPermissions = $this->dbSlave->fetchAll($sql);
+            $groupPermissions = $this->db->fetchAll($sql);
             if (!empty($groupPermissions)) {
                 $groupPermissions = Utils::rekey('module', $groupPermissions);
             }
@@ -385,12 +385,12 @@ class Permissions extends Model
      */
     public function removeGroup($groupId) : bool
     {
-        $select = $this->dbSlave->select()
+        $select = $this->db->select()
             ->from($this->table(), 'id')
             ->where('`user_id`  IS NULL')
             ->where('`group_id` = ?', $groupId);
 
-        $groupIds = $this->dbSlave->fetchCol($select);
+        $groupIds = $this->db->fetchCol($select);
 
         $store = $this->getStore();
 

--- a/dvelum/src/Dvelum/App/Model/Vc.php
+++ b/dvelum/src/Dvelum/App/Model/Vc.php
@@ -83,24 +83,24 @@ class Vc extends Model
     {
         if (!is_array($record_id)) {
 
-            $sql = $this->dbSlave->select()
+            $sql = $this->db->select()
                 ->from(
                     $this->table(),
                     ['max_version' => 'MAX(version)']
                 )
                 ->where('record_id =?', $record_id)
                 ->where('object_name =?', $objectName);
-            return (integer)$this->dbSlave->fetchOne($sql);
+            return (integer)$this->db->fetchOne($sql);
 
         }
 
-        $sql = $this->dbSlave->select()
+        $sql = $this->db->select()
             ->from($this->table(), array('max_version' => 'MAX(version)', 'rec' => 'record_id'))
             ->where('`record_id` IN(?)', $record_id)
             ->where('`object_name` =?', $objectName)
             ->group('record_id');
 
-        $revs = $this->dbSlave->fetchAll($sql);
+        $revs = $this->db->fetchAll($sql);
 
         if (empty($revs))
             return [];
@@ -135,13 +135,13 @@ class Vc extends Model
      */
     public function getData($objectName, $recordId, $version)
     {
-        $sql = $this->dbSlave->select()
+        $sql = $this->db->select()
             ->from($this->table(), array('data'))
             ->where('object_name = ?', $objectName)
             ->where('record_id =?', $recordId)
             ->where('version = ?', $version);
 
-        $data = $this->dbSlave->fetchOne($sql);
+        $data = $this->db->fetchOne($sql);
 
         if (!empty($data))
             return unserialize(base64_decode($data));
@@ -156,11 +156,11 @@ class Vc extends Model
      */
     public function removeItemVc($object, $recordId)
     {
-        $select = $this->dbSlave->select()
+        $select = $this->db->select()
             ->from($this->table(), 'id')
-            ->where('`object_name` = ?', $this->dbSlave->quote($object))
+            ->where('`object_name` = ?', $this->db->quote($object))
             ->where('`record_id` = ?', $recordId);
-        $vcIds = $this->dbSlave->fetchCol($select);
+        $vcIds = $this->db->fetchCol($select);
         $store = $this->getStore();
         $store->deleteObjects($this->name, $vcIds);
     }

--- a/dvelum/src/Dvelum/Orm/Distributed/Model.php
+++ b/dvelum/src/Dvelum/Orm/Distributed/Model.php
@@ -147,6 +147,7 @@ class Model extends Orm\Model
      * @param mixed $fields - optional - the list of fields to retrieve
      * @param bool $useCache - optional, default false
      * @return array / false
+     * @throws Exception
      */
     final public function getItems(array $ids, $fields = '*', $useCache = false)
     {

--- a/dvelum/src/Dvelum/Orm/Model.php
+++ b/dvelum/src/Dvelum/Orm/Model.php
@@ -302,6 +302,7 @@ class Model
      * @param integer $id
      * @param array|string $fields — optional — the list of fields to retrieve
      * @return array
+     * @throws \Exception
      */
     public function getItem($id, $fields = ['*']) : array
     {
@@ -325,6 +326,7 @@ class Model
      * @param integer $id - object identifier
      * @param mixed $lifetime
      * @return array
+     * @throws \Exception
      */
     public function getCachedItem($id , $lifetime = false)
     {
@@ -394,7 +396,7 @@ class Model
             return $this->db->fetchRow($sql);
         }catch (\Exception $e){
             $this->logError($e->getMessage());
-            return [];
+            throw $e;
         }
     }
 
@@ -404,6 +406,7 @@ class Model
      * @param mixed $fields - optional - the list of fields to retrieve
      * @param bool $useCache - optional, defaul false
      * @return array / false
+     * @throws \Exception
      */
     public function getItems(array $ids, $fields = '*', $useCache = false)
     {

--- a/dvelum/src/Dvelum/Orm/Model/Query.php
+++ b/dvelum/src/Dvelum/Orm/Model/Query.php
@@ -349,6 +349,7 @@ class Query
     /**
      * Fetch all records
      * @return array
+     * @throws \Exception
      */
     public function fetchAll(): array
     {
@@ -356,13 +357,14 @@ class Query
             return $this->db->fetchAll($this->__toString());
         } catch (\Exception $e) {
             $this->model->logError($e->getMessage());
-            return [];
+            throw $e;
         }
     }
 
     /**
      * Fetch one
      * @return mixed
+     * @throws \Exception
      */
     public function fetchOne()
     {
@@ -370,13 +372,14 @@ class Query
             return $this->db->fetchOne($this->__toString());
         } catch (\Exception $e) {
             $this->model->logError($e->getMessage());
-            return null;
+            throw $e;
         }
     }
 
     /**
      * Fetch first result row
      * @return array
+     * @throws \Exception
      */
     public function fetchRow(): array
     {
@@ -388,13 +391,14 @@ class Query
             return $result;
         } catch (\Exception $e) {
             $this->model->logError($e->getMessage());
-            return [];
+            throw $e;
         }
     }
 
     /**
      * Fetch column
      * @return array
+     * @throws \Exception
      */
     public function fetchCol(): array
     {
@@ -402,7 +406,7 @@ class Query
             return $this->db->fetchCol($this->__toString());
         } catch (\Exception $e) {
             $this->model->logError($e->getMessage());
-            return [];
+            throw $e;
         }
     }
 
@@ -410,6 +414,7 @@ class Query
      * Count the number of rows that satisfy the filters
      * @param bool $approximateValue - Get approximate count for innodb table (only for queries without filters)
      * @return int
+     * @throws \Exception
      */
     public function getCount(bool $approximateValue = false): int
     {


### PR DESCRIPTION
Models and query should throws exception for fetch methods like fetchAll, fetchCol, fetchOne.
Fetch methods return  an empty array  on connection error. It can cause buisnes logic errors.